### PR TITLE
Use dartsim/dart/ipopt in place of the removed homebrew/science/ipopt

### DIFF
--- a/Formula/icub-main.rb
+++ b/Formula/icub-main.rb
@@ -24,7 +24,7 @@ class IcubMain < Formula
   depends_on "qt"
   depends_on "gsl"
   depends_on "opencv" => :optional
-  depends_on "homebrew/science/ipopt" => :optional
+  depends_on "dartsim/dart/ipopt" => :optional
 
   def install
     args = std_cmake_args + %w[


### PR DESCRIPTION
Workaround until ipopt is available in homebrew/core .
Ref https://github.com/robotology/homebrew-formulae/issues/12 .