### PR TITLE
Add ODE formula

### DIFF
--- a/Formula/ode.rb
+++ b/Formula/ode.rb
@@ -1,0 +1,49 @@
+class Ode < Formula
+  desc "Simulating articulated rigid body dynamics"
+  homepage "http://www.ode.org/"
+  url "https://bitbucket.org/odedevs/ode/downloads/ode-0.15.2.tar.gz"
+  sha256 "2eaebb9f8b7642815e46227956ca223806f666acd11e31708bd030028cf72bac"
+  revision 2
+  head "https://bitbucket.org/odedevs/ode/", :using => :hg
+
+  option "with-double-precision", "Compile ODE with double precision"
+  option "with-shared", "Compile ODE with shared library support"
+  option "with-x11", "Build the drawstuff library and demos"
+
+  deprecated_option "enable-double-precision" => "with-double-precision"
+  deprecated_option "enable-shared" => "with-shared"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on :x11 => :optional
+
+  def install
+    args = ["--prefix=#{prefix}"]
+    args << "--enable-double-precision" if build.with? "double-precision"
+    args << "--enable-shared" if build.with? "shared"
+    args << "--with-demos" if build.with? "x11"
+
+    inreplace "bootstrap", "libtoolize", "glibtoolize"
+    system "./bootstrap"
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <ode/ode.h>
+      int main() {
+        dInitODE();
+        dCloseODE();
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.cpp", "-I#{include}/ode", "-L#{lib}", "-lode",
+                   "-lc++", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/ode.rb
+++ b/Formula/ode.rb
@@ -6,24 +6,13 @@ class Ode < Formula
   revision 2
   head "https://bitbucket.org/odedevs/ode/", :using => :hg
 
-  option "with-double-precision", "Compile ODE with double precision"
-  option "with-shared", "Compile ODE with shared library support"
-  option "with-x11", "Build the drawstuff library and demos"
-
-  deprecated_option "enable-double-precision" => "with-double-precision"
-  deprecated_option "enable-shared" => "with-shared"
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on :x11 => :optional
 
   def install
-    args = ["--prefix=#{prefix}"]
-    args << "--enable-double-precision" if build.with? "double-precision"
-    args << "--enable-shared" if build.with? "shared"
-    args << "--with-demos" if build.with? "x11"
+    args = ["--prefix=#{prefix}", "--enable-double-precision", "--enable-shared", "--enable-libccd"]
 
     inreplace "bootstrap", "libtoolize", "glibtoolize"
     system "./bootstrap"


### PR DESCRIPTION
Differs from `homebrew-core` in the `libccd` option.
We remove it to compile `iCub_SIM`.