### PR TITLE
[YARP formula] Fix in the yarp formula: the definition of the dependency on opencv.

### DIFF
--- a/Formula/yarp.rb
+++ b/Formula/yarp.rb
@@ -24,7 +24,7 @@ class Yarp < Formula
   depends_on "eigen" => :build
   depends_on "ace"
   depends_on "jpeg"
-  depends_on "homebrew/science/opencv" => :optional
+  depends_on "homebrew/core/opencv" => :optional
   depends_on "qt" => :recommended
   depends_on "robotology/formulae/ycm" => :recommended
   depends_on "robotology/formulae/robot-testing" => :recommended


### PR DESCRIPTION
homebrew/science has been deprecated. The opencv formula has been moved to homebrew/core. This change fixes https://github.com/robotology/homebrew-formulae/issues/20.